### PR TITLE
Correct Part 1 Q15 two-NMOS topology in golden solution

### DIFF
--- a/tasks/part1-015-malformed-cmos-inverter/golden_solution.md
+++ b/tasks/part1-015-malformed-cmos-inverter/golden_solution.md
@@ -1,7 +1,5 @@
 # Golden Solution - part1-015-malformed-cmos-inverter
 
-Figure 11(b) is not a proper CMOS inverter. Compared with the normal inverter in Figure 11(a), the device polarities/source-drain orientations are effectively swapped: the upper device is an NMOS connected to `VDD`, and the lower device is a PMOS connected to ground.
+Figure 11(b) has two NMOS devices, not a complementary CMOS pair. The upper device `M1`, with its drain at `VDD` and source at `Vout`, acts as a source-follower pull-up. The lower device `M2`, with its drain at `Vout` and source at ground, acts as a common-source pull-down. Both gates are driven by `Vin`.
 
-Although both gates are driven by `Vin`, the topology does not provide the standard PMOS pull-up to `VDD` and NMOS pull-down to ground. Around a bias point it may still exhibit a small-signal response because the two transconductances act in opposite directions at the output node. A useful small-signal form is therefore set by the difference of the device transconductances, for example proportional to `(gm2 - gm1) / (gm2 + 1/ro1 + 1/ro2)` under the simplified model.
-
-The important point is that this small-signal response does not make the circuit a valid logic inverter. It does not provide the normal regenerative, rail-to-rail CMOS inverter transfer characteristic, and it should not be interpreted as a proper complementary pull-up/pull-down logic stage.
+For low `Vin`, both devices can be off and `Vout` is not actively driven. When they conduct, `M1` pulls up while `M2` pulls down, so `Vout` is set by their current balance. The circuit therefore does not provide the regenerative, rail-to-rail transfer characteristic of a CMOS inverter.


### PR DESCRIPTION
## Summary

This PR corrects the Part 1 Q15 golden solution to identify both devices in Figure 11(b) as NMOS transistors.

## Evidence

- Figure 11(a) provides an adjacent NMOS/PMOS symbol reference.
- Both `M1` and `M2` in Figure 11(b) match the NMOS symbol in Figure 11(a).
- In the original paper, the Q15 response identifies `M1` as PMOS and `M2` as NMOS and is marked incorrect.
- Figure 13 provides an additional PMOS-symbol cross-check.

## Change

The revised golden identifies `M1` as a source-follower NMOS and `M2` as a common-source NMOS. It explains that `Vout` is determined by their current balance and that the circuit is not a CMOS inverter.

The previous explicit small-signal expression is removed because it was based on the incorrect device assignment.

## Evaluation impact

Q15 results judged with the previous golden may have penalized answers that correctly recognized the two-NMOS topology. These results should be re-judged after the correction, with the changed golden hash recorded.

## Validation

- Only the Part 1 Q15 golden solution is changed.
- `git diff --check` passes.
