### PR TITLE
Polish question detail page presentation

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -674,7 +674,7 @@ async function openTaskModal(part){
       var imageUrl=t.figure?t.figure:"";
       var fh=imageUrl?"<div><h4>Figure</h4><img src=\""+esc(imageUrl)+"\" loading=lazy onerror=\"this.parentElement.style.display='none'\" alt=\"Figure for "+esc(t.slug)+"\"></div>":"";
       var pid="ta-"+part+"-"+i;
-      var link="<a href=\"/data/v1/tasks/"+encodeURIComponent(t.slug)+"\" class=\"q-answers-link\" target=\"_blank\">View all model answers &amp; scores &rarr;</a>";
+      var link="<a href=\"/data/v1/tasks/"+encodeURIComponent(t.slug)+"\" class=\"q-answers-link\">View all model answers &amp; scores &rarr;</a>";
       return"<div class=task-accordion id=\""+pid+"\"><button class=ta-header type=button aria-expanded=false onclick=\"toggleAccordion('"+part+"',"+i+")\"><div class=ta-id>"+t.id+"</div><div class=ta-q>"+esc(t.question)+"</div><div class=ta-arrow aria-hidden=true>▼</div></button><div class=ta-body><div class=ta-content>"+link+fh+"<h4>Golden Solution</h4><div class=answer-text>"+esc(t.answer)+"</div></div></div></div>";
     }).join("");
   }catch(error){

--- a/docs/question.html
+++ b/docs/question.html
@@ -28,9 +28,15 @@ nav .btn-gh:hover{background:var(--bg-card);border-color:var(--text-muted)}
 nav .btn-gh svg{width:15px;height:15px;opacity:0.7}
 main{max-width:var(--max-width);margin:0 auto;padding:32px 24px 64px}
 .q-head{margin-bottom:24px}
-.q-head .q-id{font-size:12px;color:var(--text-muted);text-transform:uppercase;letter-spacing:.05em;margin-bottom:6px}
-.q-head h1{font-size:24px;font-weight:700;letter-spacing:-0.02em;margin-bottom:8px;line-height:1.3}
+.q-head h1{font-size:26px;font-weight:700;letter-spacing:-0.02em;margin-bottom:8px;line-height:1.3;font-family:'SF Mono','Fira Code','Cascadia Code','JetBrains Mono',monospace}
 .q-head .q-meta{display:flex;gap:16px;font-size:13px;color:var(--text-muted)}
+.md-body.q-question{font-family:'Georgia','Times New Roman',serif;font-size:17px;line-height:1.8;color:var(--text-primary)}
+.md-body.q-question h1,.md-body.q-question h2,.md-body.q-question h3{font-family:'Inter',sans-serif}
+.collapsible{position:relative;overflow:hidden;transition:max-height .4s ease}
+.collapsible.collapsed{max-height:200px}
+.collapsible.collapsed::after{content:'';position:absolute;left:0;right:0;bottom:0;height:56px;background:linear-gradient(transparent,var(--bg-card));pointer-events:none}
+.view-all-btn{display:inline-block;margin:8px 0 0;padding:2px 0;background:none;border:0;font:600 13px/1.4 'Inter',sans-serif;color:var(--text-secondary);cursor:pointer;text-decoration:underline}
+.view-all-btn:hover{color:var(--text-primary)}
 .section-title{font-size:18px;font-weight:700;margin:28px 0 12px;letter-spacing:-0.02em}
 .panel{background:var(--bg-card);border:1px solid var(--border);padding:20px;margin-bottom:16px}
 .panel h3{font-size:15px;font-weight:600;margin-bottom:10px}
@@ -208,10 +214,18 @@ function render(){
   var html='';
   html+='<a href="/#tasks" class="back">&larr; Back to tasks</a>';
   html+='<div class="q-head">';
-  html+='<div class="q-id">'+esc(data.question_id)+'</div>';
-  html+='<h1>'+esc(data.question)+'</h1>';
-  html+='<div class="q-meta"><span>'+models.length+' models</span><span>3 rollouts each</span></div>';
+  html+='<h1 class="q-title">'+esc(data.question_id)+'</h1>';
   html+='</div>';
+  // full question body in a collapsible panel (collapse only if long)
+  var qText=data.question||data.instruction||"";
+  if(qText){
+    var qmd=renderMarkdown(qText);
+    var tooLong=qText.length>250;
+    html+='<div class="panel">';
+    html+='<div class="md-body q-question collapsible'+(tooLong?' collapsed':'')+'" id="qInstruction">'+qmd+'</div>';
+    if(tooLong)html+='<button type="button" class="view-all-btn" id="qViewAll">View all</button>';
+    html+='</div>';
+  }
   // figures
   if(data.figures&&data.figures.length){
     html+='<div class="figures">'+data.figures.map(function(f,i){
@@ -221,8 +235,12 @@ function render(){
   }
   // golden solution
   if(data.golden_solution){
+    var gmd=renderMarkdown(data.golden_solution);
+    var gLong=data.golden_solution.length>250;
     html+='<div class="section-title">Golden Solution</div>';
-    html+='<div class="panel"><div class="md-body md-golden">'+renderMarkdown(data.golden_solution)+'</div></div>';
+    html+='<div class="panel"><div class="md-body collapsible'+(gLong?' collapsed':'')+'" id="gSolution">'+gmd+'</div>';
+    if(gLong)html+='<button type="button" class="view-all-btn" id="gViewAll">View all</button>';
+    html+='</div>';
   }
   // legend
   html+='<div class="section-title">Model Results</div>';
@@ -240,7 +258,7 @@ function render(){
     html+='<td class="score-col"><span class="score-badge '+scoreClass(avg)+'">'+avg.toFixed(1)+'</span></td>';
     ro.sort().forEach(function(r){
       var sc=activeScore(m.rollouts[r]);
-      html+='<td><span class="rbox '+scoreClass(sc)+'" data-model="'+esc(mk)+'" data-rollout="'+r+'" title="'+esc(m.display_name)+' rollout '+r+'">'+sc.toFixed(0)+'</span></td>';
+      html+='<td><span class="rbox score-'+Math.min(4,Math.max(0,Math.round(sc)))+'" data-model="'+esc(mk)+'" data-rollout="'+r+'" title="'+esc(m.display_name)+' rollout '+r+'">'+sc.toFixed(0)+'</span></td>';
     });
     html+='</tr>';
     // detail row (hidden, toggled)
@@ -249,8 +267,31 @@ function render(){
   html+='</tbody></table>';
   document.getElementById("content").innerHTML=html;
   // render markdown in golden
-  var g=document.querySelector(".md-golden");
+  var g=document.getElementById("gSolution");
   if(g)renderLatexInElement(g);
+  // bind view-all toggle for golden solution
+  var gvab=document.getElementById("gViewAll");
+  if(gvab){
+    gvab.addEventListener("click",function(){
+      var sol=document.getElementById("gSolution");
+      var isCollapsed=sol.classList.contains("collapsed");
+      sol.classList.toggle("collapsed");
+      this.textContent=isCollapsed?"Show less":"View all";
+    });
+  }
+  // render LaTeX in question instruction
+  var qi=document.getElementById("qInstruction");
+  if(qi)renderLatexInElement(qi);
+  // bind view-all toggle for question instruction
+  var vab=document.getElementById("qViewAll");
+  if(vab){
+    vab.addEventListener("click",function(){
+      var ins=document.getElementById("qInstruction");
+      var isCollapsed=ins.classList.contains("collapsed");
+      ins.classList.toggle("collapsed");
+      this.textContent=isCollapsed?"Show less":"View all";
+    });
+  }
   // bind rollout clicks
   document.querySelectorAll(".rbox").forEach(function(box){
     box.addEventListener("click",function(){

--- a/docs/razavi-dashboard-v3.html
+++ b/docs/razavi-dashboard-v3.html
@@ -674,7 +674,7 @@ async function openTaskModal(part){
       var imageUrl=t.figure?t.figure:"";
       var fh=imageUrl?"<div><h4>Figure</h4><img src=\""+esc(imageUrl)+"\" loading=lazy onerror=\"this.parentElement.style.display='none'\" alt=\"Figure for "+esc(t.slug)+"\"></div>":"";
       var pid="ta-"+part+"-"+i;
-      var link="<a href=\"/data/v1/tasks/"+encodeURIComponent(t.slug)+"\" class=\"q-answers-link\" target=\"_blank\">View all model answers &amp; scores &rarr;</a>";
+      var link="<a href=\"/data/v1/tasks/"+encodeURIComponent(t.slug)+"\" class=\"q-answers-link\">View all model answers &amp; scores &rarr;</a>";
       return"<div class=task-accordion id=\""+pid+"\"><button class=ta-header type=button aria-expanded=false onclick=\"toggleAccordion('"+part+"',"+i+")\"><div class=ta-id>"+t.id+"</div><div class=ta-q>"+esc(t.question)+"</div><div class=ta-arrow aria-hidden=true>▼</div></button><div class=ta-body><div class=ta-content>"+link+fh+"<h4>Golden Solution</h4><div class=answer-text>"+esc(t.answer)+"</div></div></div></div>";
     }).join("");
   }catch(error){


### PR DESCRIPTION
## Summary
- Task answer links now open in the same tab (removed target=_blank)
- Fix rollout score boxes: use score-N class so colored backgrounds render
- Question panel: task slug as title, full question body in a panel with
  Georgia serif 17px; long questions (>250 chars) collapse with a plain
  underlined "View all" text toggle
- Golden Solution gets the same collapsible treatment
- Remove "N models / 3 rollouts each" meta line

## Test plan
- Short questions render fully (no toggle); long ones (e.g.
  part2-006-oscillates-change) collapse with View all
- Rollout boxes show score-colored backgrounds